### PR TITLE
Preserving build logs by mounting the logs folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && \
     find /var/log -type f | while read f; do echo -ne '' > $f; done;
 
 RUN mkdir /tmp/roger-builds
+RUN mkdir /tmp/roger-builds/logs
+RUN mkdir /tmp/roger-builds/tars
+RUN mkdir /tmp/roger-builds/sources
 
 COPY . /src
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@ cd roger
 
 docker build -t namshi/roger .
 
-docker run -ti -p 6600:6600 -v $(pwd)/db:/db -v /path/to/your/config.yml:/config.yml -v /var/run/docker.sock:/tmp/docker.sock namshi/roger
+docker run -ti -p 6600:6600 \
+-v /tmp/logs:/tmp/roger-builds/logs \
+-v $(pwd)/db:/db \
+-v /path/to/your/config.yml:/config.yml \
+-v /var/run/docker.sock:/tmp/docker.sock \
+namshi/roger
 ```
 
 If roger starts correctly, you should see

--- a/config/base.yml
+++ b/config/base.yml
@@ -9,3 +9,8 @@ routes:
   build-log:        '/api/builds/:build/log'
   build-link:       '/#/projects/:projectName/:build'
   github-hooks:     '/public/api/hooks/github'
+paths:
+  builds:   '/tmp/roger-builds/'
+  sources:  '{{ paths.builds }}/sources'
+  tars:     '{{ paths.builds }}/tars'
+  logs:     '{{ paths.builds }}/logs'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ server:
    - ./config.yml:/config.yml
    - ./examples/auth:/auth
    - ./db:/db
+   - ./logs:/tmp/roger-builds/logs
   command: nodemon /src/src/index.js --config /config.yml
   environment:
     VIRTUAL_HOST: roger.swag

--- a/src/docker.js
+++ b/src/docker.js
@@ -14,6 +14,7 @@ var tar             = require('./tar');
 var hooks           = require('./hooks');
 var publisher       = require('./publisher');
 var dispatcher      = require('./dispatcher');
+var utils           = require('./utils');
 var yaml            = require('js-yaml');
 var os              = require('os');
 var docker          = {};
@@ -39,9 +40,9 @@ function getBuildLogger(logFile) {
 }
 
 docker.schedule = function(repo, gitBranch, uuid, dockerOptions) {
-  var path        = '/tmp/roger-builds/sources/' + uuid
+  var path        = p.join(utils.path('sources'), uuid)
   var branch      = gitBranch
-  var builds      = [];
+  var builds      = []
   var cloneUrl    = repo
 
   if (branch === 'master') {
@@ -90,8 +91,8 @@ docker.schedule = function(repo, gitBranch, uuid, dockerOptions) {
 };
 
 docker.build = function(project, uuid, path, gitBranch, branch, dockerOptions){
-  var buildLogger = getBuildLogger('/tmp/roger-builds/' + uuid  + '.log')
-  var tarPath     = '/tmp/roger-builds/' + uuid  + '.tar'
+  var buildLogger = getBuildLogger(p.join(utils.path('logs'), uuid + '.log'))
+  var tarPath     = p.join(utils.path('tars'), uuid + '.tar')
   var imageId     = project.registry + '/' + project.name
   var buildId     = imageId + ':' + branch
   var author      = 'unknown@unknown.com'

--- a/src/routes.js
+++ b/src/routes.js
@@ -73,7 +73,7 @@ routes.singleBuild = function(req, res, next) {
  * by keeping an eye on its log file.
  */
 routes.buildLog = function(req, res, next) {
-  var logFile = '/tmp/roger-builds/' + req.params.build + '.log';
+  var logFile = path.join(utils.path('logs'), req.params.build + '.log');
 
   if (fs.existsSync(logFile)) {
     res.writeHead(200, {'Content-Type': 'text/plain'});

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,7 +1,9 @@
 'use strict';
 var fs          = require('fs');
+var path        = require('path');
 var growingFile = require('growing-file');
 var dispatcher  = require('./dispatcher');
+var utils       = require('./utils');
 
 module.exports = function (server) {
   var io = require('socket.io')(server);
@@ -12,7 +14,7 @@ module.exports = function (server) {
 
     /* For sending the build file*/
     ss(socket).on('get-build-log', function (stream, data) {
-      var logFile = '/tmp/roger-builds/' + data.buildId + '.log';
+      var logFile = path.join(utils.path('logs'), data.buildId + '.log');
       var growingStream = {};
 
       if (fs.existsSync(logFile)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,18 @@
-var url   = require('url');
-var _     = require('lodash');
-var utils = {};
+var url     = require('url');
+var _       = require('lodash');
+var config  = require('./config');
+var utils   = {};
+
+utils.path = function(to) {
+  return config.get('paths.' + to);
+}
 
 /**
  * Utility function that takes an
  * object and recursively loops
  * through it replacing all "sensitive"
  * informations with *****.
- * 
+ *
  * This is done to print out objects
  * without exposing passwords and so
  * on.
@@ -15,40 +20,40 @@ var utils = {};
 utils.obfuscate = function(object) {
   object = _.clone(object);
   var stopWords = ['password', 'github', 'github-token', 'token', 'access-key', 'secret']
-  
+
   _.each(object, function(value, key){
     if (typeof value === 'object') {
       object[key] = utils.obfuscate(value);
     }
-    
+
     if (_.isString(value)) {
       object[key] = utils.obfuscateString(value);
-      
+
       if (_.contains(stopWords, key)) {
         object[key] = '*****'
       }
     }
   })
-  
-  return object;  
+
+  return object;
 };
 
 /**
  * Takes a string and remove all sensitive
  * values from it.
- * 
+ *
  * For example, if the string is a URL, it
  * will remove the auth, if present.
  */
 utils.obfuscateString = function(string) {
   var parts = url.parse(string);
-  
+
   if (parts.host && parts.auth) {
     parts.auth = null;
-    
+
     return url.format(parts);
   }
-  
+
   return string;
 }
 


### PR DESCRIPTION
@akimyonoglu this is the last change I wanted to do before making it public -- there are other things to work on but nothing crazy from my side.

With this change I just standardized some paths so that we can mount a volume under `/tmp/roger-builds/logs` and preserve build logs when we restart Roger.

Currently, if you redeploy roger, all build logs are lost (though builds are saved in its DB). I'm not sure whats the best way going forward, but for a single-instance/container Roger deployment this works well.

I am going to merge to master!
