### PR TITLE
More readable email notifications

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -5,29 +5,29 @@ var notifications = {};
 
 /**
  * Trigger notifications for a specific project.
- * 
+ *
  * @param project
  * @param branch
  * @param options {buildId, uuid, logger}
  */
 notifications.trigger = function(project, branch, options){
   options.logger.info('[%s] Sending notifications for %s', options.buildId, options.uuid);
-  var comments = ['[' + options.project.name + '] Build ' + options.uuid + ' was successful'];
-  
+  var comments = ['[' + options.project.name + ':' + branch + '] BUILD PASSED'];
+
   if (options.result instanceof Error) {
-    comments = ['[' + options.project.name + '] Build ' + options.uuid + ' broken: ' + options.result.message];
+    comments = ['[' + options.project.name + ':' + branch + '] BUILD FAILED: ' + options.result.message];
   }
-  
+
   comments.push("You can check the build output at " + router.generate('build-link', {build: options.uuid, projectName: project.name}, true));
-  
+
   if (_.isArray(project.notify)) {
     _.each(project.notify, function(handler){
       options.author    = options.author;
       options.branch    = branch;
       options.comments  = _.clone(comments);
-      
+
       var notificationOptions = (project.notifications && project.notifications[handler]) || config.get('notifications.' + handler);
-      
+
       try {
         require('./notifications/' + handler)(project, _.clone(options), notificationOptions);
       } catch(err) {


### PR DESCRIPTION
I change what we send through the notifications to avoid ahowing the build uuid (useless). Now you only get to see "Build passed / failed" which should be more helpful.

In the long term, I think having a default template is the way to go, and then anyone can override it with it's own template, ie:

``` yaml
notifications:
  template: "[{{project}}:{{branch}}] Build {{feedback}}! {% if feedback === 'passed' %}YOLO!{% endif %}"
# produces [roger:test-branch] Build passed! YOLO!
```