### PR TITLE
Fixing roger browser performance issues

### DIFF
--- a/src/client/styles/App.scss
+++ b/src/client/styles/App.scss
@@ -56,9 +56,9 @@ html,body{
 }
 
 .build-output,
-.build-output__log {
+{
   background-color: #000;
-  color: lightgreen;
+  position: relative;
 }
 .build-output__header {
   color: #21D4F4;
@@ -66,9 +66,13 @@ html,body{
     color: lightblue;
     font-weight: bold;
   }
+  .auto-update {
+    float: right;
+  }
 }
 .build-output__log {
   width: 100%;
-  max-height: 75vh;
-  overflow: scroll;
+  height: 75vh;
+  border: 2px solid limegreen;
+  background-color: #fff;
 }


### PR DESCRIPTION
@odino @razanbilwani @p16 

Roger had major UI issues in browser. This is because:

We use the socket-stream to update the build logs inside a `<pre>` tag. Streams created some memory issues, however, the major problem was rendering the large text blocks.

The log files are having large size will get rendered every time the socket updates. After some analysis, I found everytime a **textNode** is created inside the `<pre>`, it creates a reflow and repaint. Moreover, there are thousands of text nodes. Unfortunately, there is no way I could find to fix this.

However, when you access the log directly in browser, it will manage the rendering properly. So I guess, the best way to do it in an `IFRAME` instead of streams and manually rendering inside a `<PRE>` tag.

In this PR, I removed the code for `socket-streams` ( only for buildOutput log ) and used an IFRAME to display the output.  Also, I added a checkbox to toggle the automatic scrolling inside the build output.

Caveat:

1. Styling inside the IFRAME is difficult. Though, I could able to do it in JavaScript, it was inconsistent.
