### PR TITLE
allow the bucket path to be empty

### DIFF
--- a/src/publisher/s3.js
+++ b/src/publisher/s3.js
@@ -72,7 +72,7 @@ function uploadDirectoryToS3(options) {
         f = f.join('/')
         
         options.path = file;
-        options.name = path.join(options.bucketPath, f);
+        options.name = path.join(options.bucketPath || '', f);
         options.logger.info("[%s] Uploading %s in s3://%s/%s", options.buildId, file, options.bucket, options.name);
         
         uploads.push(Q.Promise(function(resolve, reject){


### PR DESCRIPTION
Currently, if you don't pass the bucket initial path it throws an error.

we don't need the bucket initial path always.