### PR TITLE
Upgrade dockerode and fix tagging wrong image

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/namshi/roger",
   "dependencies": {
-    "aws-sdk": "^2.1.8",
+    "aws-sdk": "^2.6.4",
     "body-parser": "^1.10.2",
-    "dockerode": "2.3.1",
+    "dockerode": "2.4.3",
     "express": "^4.11.1",
     "express-session": "^1.11.3",
     "github": "^0.2.3",

--- a/src/builder.js
+++ b/src/builder.js
@@ -154,11 +154,11 @@ builder.build = function(project, uuid, path, gitBranch, branch, dockerOptions) 
     buildLogger.info('[%s] Created tarball for %s', buildId, uuid);
 
     return docker.buildImage(project, tarPath, imageId + ':' + branch, buildId, buildLogger, dockerOptions, uuid);
-  }).then(function() {
-    buildLogger.info('[%s] %s built succesfully', buildId, uuid);
-    buildLogger.info('[%s] Tagging %s', buildId, uuid);
+  }).then(function(realBuildId) {
+    buildLogger.info('[%s] %s built succesfully as imageId: %s', buildId, uuid, realBuildId);
+    buildLogger.info('[%s] Tagging %s as imageId: %s', buildId, uuid, realBuildId);
 
-    return docker.tag(imageId, buildId, branch, buildLogger);
+    return docker.tag(imageId, realBuildId, branch, buildLogger);
   }).then(function(image) {
     return publisher.publish(docker.client, buildId, project, buildLogger).then(function() {
       return image;


### PR DESCRIPTION
## Why

With the new docker api, there is an issue whereby once an image with `latest` tag is built, any image being built afterwards uses the image id of the previously built `latest` tag except the `latest` tagged-image is removed.

This was because `var image = docker.client.getImage(imageId)` used.
One new docker API servers, once the `latest` tagged-image is built, var image would default to latest image `hub/repo:latest` instead of `hub/repo`. On Cli try .

Steps to reproduce on cli
* Remove all alpine images
* `docker pull alpine:3.5`
*`docker image inspect alpine` => You should get an error
* `docker pull alpine:latest`
*`docker image inspect alpine` => This should default to `alpine:latest`

The PR ensures that the images are tagged from the imageID instead of repo-name, then retrieves the image tag which is pushed to the registry