### PR TITLE
git.getLastCommit works with annotated tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,18 +781,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs-extra": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1434,22 +1422,39 @@
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "nodegit": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.20.3.tgz",
-      "integrity": "sha1-pEFy2wjIM83LGrm7wsgyzgWJiBU=",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.22.0.tgz",
+      "integrity": "sha512-Vj9C9MtNFKE8+DvMeLhRIHh7BxpTxIbg8UTI38z388E91MXBrxAP6ZYuVYt1gB+8UhY/12qEdKbaQX5HiemmUQ==",
       "requires": {
-        "fs-extra": "0.26.7",
+        "fs-extra": "0.27.0",
         "lodash": "4.17.5",
-        "nan": "2.8.0",
+        "nan": "2.10.0",
         "node-gyp": "3.6.2",
         "node-pre-gyp": "0.6.39",
         "promisify-node": "0.3.0"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.27.0.tgz",
+          "integrity": "sha1-ZtTCXR0sao2v7XcYz8/+kw8TssA=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "netroute": "^1.0.2",
     "node-dir": "^0.1.15",
     "node-uuid": "^1.4.7",
-    "nodegit": "^0.20.1",
+    "nodegit": "^0.22.0",
     "passport": "^0.2.2",
     "passport-github2": "^0.1.10",
     "passport-local": "^1.0.0",

--- a/src/git.js
+++ b/src/git.js
@@ -4,16 +4,27 @@ var utils   = require("./utils");
 var Git     = require("nodegit");
 var git     = {};
 
+let getTag = function (repo, branch) {
+  return repo.getTagByName(branch)
+    .then(function (tag) {
+      return tag.owner().getCommit(tag.targetId());
+    });
+};
+
 /**
  * Returns the last commit made in the repo
  * on the given branch.
  */
-git.getLastCommit = function(repository, branch) {
+git.getLastCommit = function (repository, branch) {
   return Git.Repository.open(repository)
-  .then(function(repo) {
-    return repo.getBranchCommit(branch);
-  });
-}
+    .then(function (repo) {
+      return repo.getBranchCommit(branch)
+        .catch(function () {
+          // getBranchCommit fails in case "branch" is an annotated tag
+          return getTag(repo, branch);
+        });
+    })
+};
 
 /**
  * Clones the repository at the specified path,


### PR DESCRIPTION
If the last commit is an annotated tag git.getLastCommit fails with the error message "The requested type does not match the type in ODB".
This commit solves the issue using "getTagByName" method as a fallback