### PR TITLE
Fix json object using owner instead of user

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -14,7 +14,7 @@ function getPullRequest(token, user, repo, number) {
   var client = createClient(token);
   
   client.pullRequests.get({
-    user: user,
+    owner: user,
     repo: repo,
     number: number
   }, function(err, pr){


### PR DESCRIPTION
In order to send the proper request using github module, the get pull-request call must follow the following naming:
https://github.com/octokit/rest.js/blob/v9.2.0/lib/routes.json#L3787