### PR TITLE
[Security] Fix unsafe CORS configuration

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -4,6 +4,7 @@ var path        = require('path');
 var growingFile = require('growing-file');
 var dispatcher  = require('./dispatcher');
 var utils       = require('./utils');
+var config      = require('./config');
 
 module.exports = function (server) {
   var io = require('socket.io')(server);
@@ -12,18 +13,11 @@ module.exports = function (server) {
   io.on('connection', function (socket) {
     console.log('websocket connected');
 
-    /* For sending the build file*/
-    ss(socket).on('get-build-log', function (stream, data) {
-      var logFile = path.join(utils.path('logs'), data.buildId + '.log');
-      var growingStream = {};
-
-      if (fs.existsSync(logFile)) {
-        growingStream = growingFile.open(logFile, {timeout: 300000, interval: 1000});
-        growingStream.pipe(stream);
-        growingStream.on('end', function() {
-          console.log('stream is closed');
-        });
-      }
+   io.origins((origin, callback) => {
+        if (origin !== config.get('app.url') + '/') {
+            return callback('origin not allowed', false);
+        }
+      callback(null, true);
     });
 
     /* When the projects db updated*/


### PR DESCRIPTION
**CORS enabled by default on socket.io server, allowing cross origin requests**

The CORS configuration is enabled by default by socket.io, and roger hasn't set the configuration, therefore socket.io will respond to requests from other origins with the Access-Control-Allow-Credentials and Access-Control-Allow-Origin on any request. This will allow an attacker to make cross-origin requests to the socket.io server, as every origin is allowed.

The CORS misconfiguration could be fruther escalated due to a path traversal vulnerability. This would allow an attacker to:

* Retrieve any .log file in the Docker container.
* Retrieve build log files.


The attacker requires the following from the victim:

* Authenticated to roger.
* Visting attacker's website which loads the following PoC (setting up ws connection with roger). This could be included on a more popular web page (via a XSS vulnerability) to have more effect:

Proof of Concept
```html
<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.1.0/socket.io.js" type="text/javascript"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io-stream/0.9.1/socket.io-stream.js"></script>
<script type="text/javascript">
            // The roger instance host, for me it was localhost:8082, and I was running the host from a different origin
            var socket = io.connect('http://localhost:8082');

            var stream = ss.createStream();

            // Emit get-build-log, supply stream and buildId, where a path traversal vulnerability was found.
            ss(socket).emit('get-build-log', stream, {buildId: "../../../var/log/dpkg"});

            stream.on('data', function(chunk) {

                // print chunks of data in console.log

                console.log(chunk.toString());

            });



</script>
```
My first thought was that the socket.io server wasn't used anymore, but apparently it is still required. I have set socket.io to only accept the origin specified in the configuration file at `app.url`. This should fix the issue and disallow any other origins to interact with the socket.io server.

I have removed the `get-build-log` event as it's not required anymore. The functionality was removed on the client side in #33.

I have used https://socket.io/docs/server-api/#server-origins-fn.