### PR TITLE
Fix getting commit from tags

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -138,7 +138,7 @@ builder.build = function(project, uuid, path, gitBranch, branch, dockerOptions) 
   }).then(function() {
     return storage.saveBuild(uuid, buildId, project.id, branch, 'started');
   }).then(function() {
-    return git.getLastCommit(path, gitBranch);
+    return git.getCommit(path, gitBranch);
   }).then(function(commit) {
     author = commit.author().email();
     sha = commit.sha();

--- a/src/git.js
+++ b/src/git.js
@@ -17,12 +17,12 @@ git.getCommit = function(path, name) {
       return Git.Reference.dwim(repo, name)
         .then(function(ref) {
           // Convert tags to commit objects
-          return ref.peel(Git.Object.TYPE.COMMIT)
+          return ref.peel(Git.Object.TYPE.COMMIT);
         })
         .then(function(ref) {
           // Get the commit object from the repo
-          return Git.Commit.lookup(repo, ref.id())
-        })
+          return Git.Commit.lookup(repo, ref.id());
+        });
   });
 }
 

--- a/src/git.js
+++ b/src/git.js
@@ -11,7 +11,6 @@ var git     = {};
  * @return {promise}     - A promise that resolves to the commit
  */
 git.getCommit = function(path, name) {
-  branch = 'refs/heads/master'
   return Git.Repository.open(path)
     .then(function(repo) {
       // Look up the branch or tag by its name

--- a/src/git.js
+++ b/src/git.js
@@ -10,8 +10,17 @@ var git     = {};
  */
 git.getLastCommit = function(repository, branch) {
   return Git.Repository.open(repository)
-  .then(function(repo) {
-    return repo.getBranchCommit(branch);
+    .then(function(repo) {
+      // Look up the branch or tag by its short name
+      return Git.Reference.dwim(repo, branch)
+        .then(function(ref) {
+          // Convert tags to commit objects
+          return ref.peel(Git.Object.TYPE.COMMIT)
+        })
+        .then(function(ref) {
+          // Get the commit object from the repo
+          return Git.Commit.lookup(repo, ref.id())
+        })
   });
 }
 

--- a/src/git.js
+++ b/src/git.js
@@ -5,14 +5,17 @@ var Git     = require("nodegit");
 var git     = {};
 
 /**
- * Returns the last commit made in the repo
- * on the given branch.
+ * Get a nodegit commit object from a reference name
+ * @param  {string} path - The path to the Git repository
+ * @param  {string} name - The name of the reference to get
+ * @return {promise}     - A promise that resolves to the commit
  */
-git.getLastCommit = function(repository, branch) {
-  return Git.Repository.open(repository)
+git.getCommit = function(path, name) {
+  branch = 'refs/heads/master'
+  return Git.Repository.open(path)
     .then(function(repo) {
-      // Look up the branch or tag by its short name
-      return Git.Reference.dwim(repo, branch)
+      // Look up the branch or tag by its name
+      return Git.Reference.dwim(repo, name)
         .then(function(ref) {
           // Convert tags to commit objects
           return ref.peel(Git.Object.TYPE.COMMIT)

--- a/src/github.js
+++ b/src/github.js
@@ -106,7 +106,8 @@ github.getBuildInfoFromHook = function(req) {
   
   if (repo) {
     if (req.headers['x-github-event'] === 'push') {
-      info.branch  = payload.ref.replace(/^.+\//, '');
+      // Remove leading /refs/*/ from branch or tag name
+      info.branch  = payload.ref.replace(/^refs\/[^\/]+\//, '');
       deferred.resolve(info);
     } else if (req.headers['x-github-event'] === 'create' && payload.ref_type === 'tag') {
       info.branch = payload.ref

--- a/src/github.js
+++ b/src/github.js
@@ -106,7 +106,7 @@ github.getBuildInfoFromHook = function(req) {
   
   if (repo) {
     if (req.headers['x-github-event'] === 'push') {
-      info.branch  = payload.ref.replace('refs/heads/', '');
+      info.branch  = payload.ref.replace(/^.+\//, '');
       deferred.resolve(info);
     } else if (req.headers['x-github-event'] === 'create' && payload.ref_type === 'tag') {
       info.branch = payload.ref


### PR DESCRIPTION
Allow tags (annotated or plain) to be used as branch reference. This fixes the error also reported in #46:
> The requested type does not match the type in ODB

Allow GitHub's `push` webhook event to send tags. This fixes the following error:
> fatal: Remote branch refs/heads/1.0.0 not found in upstream origin

