### PR TITLE
Add branch and tag name filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,46 @@ redis-server:
   dockerfilePath: server/src
 ```
 
+#### Branch and tag filtering
+
+Want to only build from specific branches or tags? Builds that are started automatically by a webhook (see [build hooks](#build-hooks) below), can be filtered, based on the name of the branch or tag sent by the webhook. Webhooks that don't match the rules will not cause a build to be scheduled.
+
+Matching rules can be configured with one or more of the following properties:
+
+- **branches**: An array of branch names that should be built
+- **patterns**: An array of JavaScript-compatible regular expressions for matching branch and tag names to be built
+- **tags**: A boolean allowing all tags to be built when set to `true`
+
+The following example will allow the branches `develop` and `master` to be built, as well as any branch or tag matching the regular expression `v\d+\.\d+\.\d+$`, which looks for a version number in the form `v1.0.0`.
+
+```yaml
+redis:
+  registry: dockerhub
+
+settings:
+  matching:
+    branches:
+      - master
+      - develop
+    patterns:
+      - ^v\d+\.\d+\.\d+$
+```
+
+The following example will allow the `master` branch, plus all tags to be built:
+
+```yaml
+redis:
+  registry: dockerhub
+
+settings:
+  matching:
+    branches:
+      - master
+    tags: true
+```
+
+Note that filtering only applies to webhook builds, and only when the `matching` options are configured. Builds scheduled using the web UI or the `api/build` endpoint are not affected by these filters.
+
 ### Server configuration
 
 Roger will read a `/config.yml` file that you

--- a/src/builder.js
+++ b/src/builder.js
@@ -79,21 +79,21 @@ builder.schedule = function(repo, gitBranch, uuid, dockerOptions, checkBranch = 
       return yaml.safeLoad(fs.readFileSync(p.join(path, 'build.yml'), 'utf8'));
     } catch(err) {
       logger.error(err.toString(), err.stack);
-
-      /**
-       * In case the .build.yml is not found, let's build
-       * the smallest possible configuration for the current
-       * build: we will take the repo name and build this
-       * project, ie github.com/antirez/redis will build
-       * under the name "redis".
-       */
-      var buildConfig = {};
-      buildConfig[cloneUrl.split('/').pop()] = {};
-
-      return buildConfig;
+      return {};
     }
   }).then(async function(config) {
     const { settings, ...projects } = config;
+
+    /**
+     * In case no projects are defined, let's build
+     * the smallest possible configuration for the current
+     * build: we will take the repo name and build this
+     * project, ie github.com/antirez/redis will build
+     * under the name "redis".
+     */
+    if (Object.keys(projects).length === 0) {
+      projects[cloneUrl.split('/').pop()] = {};
+    }
 
     // Check branch name matches rules
     const matchedBranch = !checkBranch || await matching.checkNameRules(settings, gitBranch, path);

--- a/src/builder.js
+++ b/src/builder.js
@@ -47,13 +47,14 @@ var builder = {};
  * file, then trigger as many builds as we find
  * in the configured build.yml.
  *
- * @param  {string} repo
- * @param  {string} gitBranch
- * @param  {string} uuid
- * @param  {object} dockerOptions
+ * @param  {string}  repo
+ * @param  {string}  gitBranch
+ * @param  {string}  uuid
+ * @param  {object}  dockerOptions
+ * @param  {boolean} checkBranch - Enable branch checking by setting to true
  * @return {void}
  */
-builder.schedule = function(repo, gitBranch, uuid, dockerOptions) {
+builder.schedule = function(repo, gitBranch, uuid, dockerOptions, checkBranch = false) {
   var path        = p.join(utils.path('sources'), uuid);
   var branch      = gitBranch;
   var builds      = [];
@@ -94,8 +95,8 @@ builder.schedule = function(repo, gitBranch, uuid, dockerOptions) {
     const { settings, ...projects } = config;
 
     // Check branch name matches rules
-    const match = await builder.matchBranchName(settings, gitBranch, path)
-    if (!match) {
+    const matchedBranch = !checkBranch || await builder.matchBranchName(settings, gitBranch, path)
+    if (!matchedBranch) {
       logger.info('The branch name didn\'t match the defined rules')
       return builds;
     }

--- a/src/builder.js
+++ b/src/builder.js
@@ -81,8 +81,8 @@ builder.schedule = function(repo, gitBranch, uuid, dockerOptions, checkBranch = 
       logger.error(err.toString(), err.stack);
       return {};
     }
-  }).then(async function(config) {
-    const { settings, ...projects } = config;
+  }).then(async function(buildConfig) {
+    const { settings, ...projects } = buildConfig;
 
     /**
      * In case no projects are defined, let's build

--- a/src/builder.js
+++ b/src/builder.js
@@ -311,11 +311,11 @@ storage.getPendingBuilds().then(function(builds) {
  */
 builder.matchBranchName = async function(settings, name, path) {
   // Default settings match all branches
-  if (!settings || !settings.match) {
+  if (!settings || !settings.matching) {
     return true;
   }
 
-  const { branches, patterns, tags } = settings.match;
+  const { branches, patterns, tags } = settings.matching;
 
   // Allow exact branch names
   if (branches && branches.includes(name)) {

--- a/src/git.js
+++ b/src/git.js
@@ -27,6 +27,29 @@ git.getCommit = function(path, name) {
 }
 
 /**
+ * Check the type of the specified reference name
+ * @param  {string} path - The path to the Git repository
+ * @param  {string} name - The name of the reference to check
+ * @return {promise}     - A promise that resolves to the result,
+ *                         either 'tag', 'branch', or 'commit'
+ */
+git.getRefType = function(path, name) {
+  return Git.Repository.open(path)
+    then(function(repo) {
+      return Git.Reference.dwim(repo, name)
+        .then(function(ref) {
+          if (ref.isTag()) {
+            return 'tag';
+          }
+          if (ref.isBranch()) {
+            return 'branch';
+          }
+          return 'commit';
+        });
+    });
+}
+
+/**
  * Clones the repository at the specified path,
  * only fetching a specific branch -- which is
  * the one we want to build.

--- a/src/matching.js
+++ b/src/matching.js
@@ -1,0 +1,43 @@
+const _ = require('lodash');
+const git = require('./git');
+
+const matching = {};
+
+/**
+ * Check branch name against settings match rules
+ * @param  {object} settings - The global settings key from build.yml
+ * @param  {string} name     - The name of the branch to be built
+ * @param  {string} path     - The path to the Git repository
+ * @return {boolean}         - The result of the check, true if match is found
+ */
+matching.checkNameRules = async function(settings, name, path) {
+  // Default settings match all branches
+  if (!settings || !settings.matching) {
+    return true;
+  }
+
+  const { branches, patterns, tags } = settings.matching;
+
+  // Allow exact branch names
+  if (branches && branches.includes(name)) {
+    return true;
+  }
+
+  // Allow tags when enabled
+  if (tags === true && await git.getRefType(path, name) === 'tag') {
+    return true;
+  }
+
+  // Allow any name that matches a regex pattern
+  if (patterns && _.some(patterns, function(pattern) {
+      const regex = new RegExp(pattern);
+      return regex.test(name);
+    })) {
+    return true;
+  }
+
+  // Disallow if no sub-keys are defined
+  return false;
+}
+
+module.exports = matching;

--- a/src/routes.js
+++ b/src/routes.js
@@ -105,7 +105,7 @@ routes.config = function(req, res, next) {
  */
 routes.buildFromGithubHook = function(req, res) {
   github.getBuildInfoFromHook(req).then(function(info){
-    builder.schedule(info.repo, info.branch || "master", uuid.v4())
+    builder.schedule(info.repo, info.branch || "master", uuid.v4(), null, true);
 
     res.status(202).send({message: "builds triggered", info: info});
     return;


### PR DESCRIPTION
This adds a global `settings` key to the `build.yml` file, where users can configure options for the whole project. This may cause a problem if users have already configured a project called settings, but I consider this unlikely, and it seems like the best name for the key.

Matching options available are `branches` (match full branch or tag name), `patterns` (regex match on branch or tag name) and `tags` (build all tags). See the readme for full details.

I've written tests for the matching logic in `matching.checkNameRules` using Jest. I haven't included them in this PR, as it's not clear what you have planned for testing. The readme says all testing is manual, but the `npm test` command is set to `mocha`. If you're happy for me to include the tests, just let me know and I'll merge them into this branch. You can find them at https://github.com/JonathanHolvey/roger/blob/branch-rules-tests/src/__tests__/matching.test.js